### PR TITLE
NLPCRAFT-49: Probe hangs on stop.

### DIFF
--- a/src/main/scala/org/apache/nlpcraft/common/util/NCUtils.scala
+++ b/src/main/scala/org/apache/nlpcraft/common/util/NCUtils.scala
@@ -952,9 +952,9 @@ object NCUtils extends LazyLogging {
             override def isInterrupted: Boolean = super.isInterrupted || stopped
             
             override def interrupt(): Unit = {
-                super.interrupt()
-                
                 stopped = true
+
+                super.interrupt()
             }
             
             override def run(): Unit = {


### PR DESCRIPTION
This PR should fix NLPCRAFT-49.

**Details:**
In the current version, an interrupted thread may receive an `InterruptedException` and check the `isInterrupted()` flag while the the `stopped` is not updated yet.
This causes problems if the interrupted thread doesn't reset `isInterrupted()` flag in `InterruptedException` handling code. 

The fix is to change the order in which flags are updated.
