### PR TITLE
[NLPCRAFT-327] Fixed .nlpcraft directory not present issue

### DIFF
--- a/bin/nlpcraft.sh
+++ b/bin/nlpcraft.sh
@@ -24,6 +24,19 @@
 # POSIX-complaint implementation for GNU "readlink -f" functionality.
 # Works on Linux/MacOS.
 #
+
+# NLPCraft hidden directory
+#NLPCRAFT_LOGDIR=$HOME/.nlpcraft
+#
+## Create necessary directories for NLPCraft to run
+#create_dirs() {
+#  if [ ! -d "$NLPCRAFT_LOGDIR" ]; then
+#    mkdir $NLPCRAFT_LOGDIR >/dev/null 2>&1 || echo "$NLPCRAFT_LOGDIR does not exist & failed creation.Please create it."
+#  fi
+#}
+#
+#create_dirs
+
 readlinkf_posix() {
   [ "${1:-}" ] || return 1
   max_symlinks=40


### PR DESCRIPTION
JIRA: [NLPCRAFT-327](https://issues.apache.org/jira/browse/NLPCRAFT-327)

When I first built NLPCraft, the `.nlpcraft` folder did not auto-create. This code fix will make NLPCraft run without an error by auto-creating the `.nlpcraft` folder if not already present.