### PR TITLE
fix time model to include map data

### DIFF
--- a/nlpcraft-examples/time/src/main/scala/org/apache/nlpcraft/examples/time/TimeModel.scala
+++ b/nlpcraft-examples/time/src/main/scala/org/apache/nlpcraft/examples/time/TimeModel.scala
@@ -19,6 +19,7 @@ package org.apache.nlpcraft.examples.time
 import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.nlpcraft.*
 import org.apache.nlpcraft.annotations.*
 import org.apache.nlpcraft.examples.time.utils.cities.*
@@ -77,8 +78,11 @@ class TimeModel extends NCModel(
                 "localTime" -> ZonedDateTime.now(ZoneId.of(tmz)).format(FMT)
             )
 
-        try
-            NCResult(new ObjectMapper(new YAMLFactory).writeValueAsString(m))
+        try {
+            val mapper = new ObjectMapper(new YAMLFactory)
+            mapper.registerModule(DefaultScalaModule)
+            NCResult(mapper.writeValueAsString(m))
+        }
         catch
             case e: JsonProcessingException => throw new RuntimeException("YAML conversion error.", e)
 


### PR DESCRIPTION
The model goes to the trouble of collecting the data map but it won't be included currently in the result.

Currently, the YAML looks like this:

```
---
empty: false
traversableAgain: true
```

After this change, it will look like this:

```
---
localTime: "12 Mar. 2023, 9:35:07 pm"
city: "New york city"
timezone: "America/New_York"
country: "United states"
lon: -74.00597
lat: 40.71427
```
It isn't strictly needed for the current test, since it only checks the intent, but the current model make more sense with it included.