### PR TITLE
Fix incorrect documentation links

### DIFF
--- a/nlpcraft-examples/calculator/README.md
+++ b/nlpcraft-examples/calculator/README.md
@@ -27,7 +27,7 @@ This example data model represents simple calculator. It supports '+', '-', '*' 
 Note that first argument can be omitted and last operation result will be used instead. 
 
 ### Documentation  
-See [Getting Started](https://nlpcraft.apache.org/getting-started.html) guide for more instructions on how to run these examples.
+See [Getting Started](https://nlpcraft.apache.org/docs.html) guide for more instructions on how to run these examples.
 
 For any questions, feedback or suggestions:
 

--- a/nlpcraft-examples/pizzeria/README.md
+++ b/nlpcraft-examples/pizzeria/README.md
@@ -26,7 +26,7 @@
 This example provides a simple implementation for NLI-powered pizzeria order bot.
 
 ### Documentation
-See [Getting Started](https://nlpcraft.apache.org/getting-started.html) guide for more instructions on how to run these examples.
+See [Getting Started](https://nlpcraft.apache.org/docs.html) guide for more instructions on how to run these examples.
 
 For any questions, feedback or suggestions:
 

--- a/nlpcraft-examples/time/README.md
+++ b/nlpcraft-examples/time/README.md
@@ -27,7 +27,7 @@ This example data model answers the questions about current time, either local t
 It provides YAML response with time and timezone information and uses YAML model definition.
 
 ### Documentation  
-See [Getting Started](https://nlpcraft.apache.org/getting-started.html) guide for more instructions on how to run these examples.
+See [Getting Started](https://nlpcraft.apache.org/docs.html) guide for more instructions on how to run these examples.
 
 For any questions, feedback or suggestions:
 


### PR DESCRIPTION
Corrected link "/getting-started.html" -> "/docs.html"